### PR TITLE
Allow usage of Client without any middlewares

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@
 
 * [Hiro Kobashi](https://github.com/kobaski)
 * [sfranky](https://github.com/sfranky)
+* [eltermann](https://github.com/eltermann)

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -24,9 +24,11 @@ class Client(object):
     __register_path__ = 'register'
     __register_search_path__ = 'register/search'
 
-    def __init__(self, accept_type='xml', middlewares=[Throttler()]):
+    def __init__(self, accept_type='xml', middlewares=None):
         self.accept_type = 'application/{0}'.format(accept_type)
         self.middlewares = middlewares
+        if not middlewares:
+            self.middlewares = [Throttler()]
         self.request = Request(self.middlewares)
 
     def _check_for_exceeded_quota(self, response):
@@ -126,7 +128,7 @@ class Client(object):
 
 class RegisteredClient(Client):
     def __init__(
-        self, key, secret, accept_type='xml', middlewares=[Throttler()]
+        self, key, secret, accept_type='xml', middlewares=None
     ):
         super(RegisteredClient, self).__init__(accept_type, middlewares)
         self.key = key

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -24,11 +24,9 @@ class Client(object):
     __register_path__ = 'register'
     __register_search_path__ = 'register/search'
 
-    def __init__(self, accept_type='xml', middlewares=None):
+    def __init__(self, accept_type='xml', middlewares=[Throttler()]):
         self.accept_type = 'application/{0}'.format(accept_type)
         self.middlewares = middlewares
-        if not middlewares:
-            self.middlewares = [Throttler()]
         self.request = Request(self.middlewares)
 
     def _check_for_exceeded_quota(self, response):
@@ -128,7 +126,7 @@ class Client(object):
 
 class RegisteredClient(Client):
     def __init__(
-        self, key, secret, accept_type='xml', middlewares=None
+        self, key, secret, accept_type='xml', middlewares=[Throttler()]
     ):
         super(RegisteredClient, self).__init__(accept_type, middlewares)
         self.key = key

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -27,7 +27,7 @@ class Client(object):
     def __init__(self, accept_type='xml', middlewares=None):
         self.accept_type = 'application/{0}'.format(accept_type)
         self.middlewares = middlewares
-        if not middlewares:
+        if middlewares is None:
             self.middlewares = [Throttler()]
         self.request = Request(self.middlewares)
 


### PR DESCRIPTION
I want to be able to make:

```python
cli = RegisteredClient(key, secret, middlewares=[])
```
