### PR TITLE
Number service

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -13,7 +13,6 @@
 
 ## Additional services
 * Legal service
-* Number service
 * Images retrieval
 * Bulk operations
 

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -67,22 +67,25 @@ class Client(object):
         return response
 
     def _make_request_url(
-        self, service, reference_type, input, endpoint, constituents
+        self, service, reference_type, input, endpoint, constituents,
+        output_format=None
     ):
         constituents = constituents or []
         parts = [
             self.__service_url_prefix__, service, reference_type,
             input and input.__class__.__name__.lower(), endpoint,
-            ','.join(constituents)
+            ','.join(constituents),
+            output_format
         ]
         return u'/'.join(filter(None, parts))
 
     # Service requests
     def _service_request(
-        self, path, reference_type, input, endpoint, constituents
+        self, path, reference_type, input, endpoint, constituents,
+        output_format=None
     ):
         url = self._make_request_url(
-            path, reference_type, input, endpoint, constituents
+            path, reference_type, input, endpoint, constituents, output_format
         )
         return self._make_request(url, input.as_api_input())
 
@@ -137,9 +140,9 @@ class Client(object):
             raise exceptions.InvalidInputFormatMapping(
                 'Cannot convert from %s to %s' % (input_format, output_format)
             )
-        constituents = [output_format]
         return self._service_request(
-            self.__number_path__, reference_type, input, None, constituents
+            self.__number_path__, reference_type, input, None, None,
+            output_format
         )
 
 class RegisteredClient(Client):

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -23,6 +23,7 @@ class Client(object):
     __published_data_search_path__ = 'published-data/search'
     __register_path__ = 'register'
     __register_search_path__ = 'register/search'
+    __number_path__ = 'number-service'
 
     def __init__(self, accept_type='xml', middlewares=None):
         self.accept_type = 'application/{0}'.format(accept_type)
@@ -125,6 +126,21 @@ class Client(object):
         range = dict(key='Range', begin=range_begin, end=range_end)
         return self._search_request(self.__register_search_path__, cql, range)
 
+    def number(self, reference_type, input, output_format):
+        allowed_mappings = {
+            'original': ['docdb', 'epodoc'],
+            'docdb': ['original', 'epodoc'],
+            'epodoc': ['original'],
+        }
+        input_format = input.__class__.__name__.lower()
+        if not output_format in allowed_mappings[input_format]:
+            raise exceptions.InvalidInputFormatMapping(
+                'Cannot convert from %s to %s' % (input_format, output_format)
+            )
+        constituents = [output_format]
+        return self._service_request(
+            self.__number_path__, reference_type, input, None, constituents
+        )
 
 class RegisteredClient(Client):
     def __init__(

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -74,8 +74,7 @@ class Client(object):
         parts = [
             self.__service_url_prefix__, service, reference_type,
             input and input.__class__.__name__.lower(), endpoint,
-            ','.join(constituents),
-            output_format
+            ','.join(constituents), output_format
         ]
         return u'/'.join(filter(None, parts))
 

--- a/epo_ops/exceptions.py
+++ b/epo_ops/exceptions.py
@@ -16,6 +16,11 @@ class MissingRequiredValue(ValueError):
     """User did not supply a required value."""
 
 
+# Number service error
+class InvalidInputFormatMapping(ValueError):
+    """User provided invalid (input format, output format) pair for number."""
+
+
 # OPS quota errors
 class AnonymousQuotaPerMinuteExceeded(HTTPError):
     """Anonymous per minute quota exceeded."""

--- a/tests/helpers/api_helpers.py
+++ b/tests/helpers/api_helpers.py
@@ -4,6 +4,7 @@ import requests
 
 from epo_ops.models import Docdb
 from epo_ops.models import Epodoc
+from epo_ops.models import Original
 
 data = ('publication', Docdb('1000000', 'EP', 'A1'))
 rdata = ('publication', Epodoc('EP1000000'))
@@ -81,4 +82,14 @@ def assert_register_search_with_range_success(client):
     assert 'register-documents' in response.text
     assert find_range(response.text, 'begin="50"')
     assert find_range(response.text, 'end="60"')
+    return response
+
+
+def assert_number_service_success(client):
+    response = client.number(
+        'application',
+        Original('2006-147056', country_code='JP', kind_code='A'),
+        'docdb'
+    )
+    assert 'ops:standardization' in response.text
     return response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ from .helpers.api_helpers import (
     assert_published_data_search_with_range_success,
     assert_published_data_success, assert_register_search_success,
     assert_register_search_with_range_success, assert_register_success,
-    issue_published_data_request
+    assert_number_service_success, issue_published_data_request
 )
 
 
@@ -52,6 +52,10 @@ def test_register_search(all_clients):
 
 def test_register_search_with_range(all_clients):
     assert_register_search_with_range_success(all_clients)
+
+
+def test_number_service_(all_clients):
+    assert_number_service_success(all_clients)
 
 
 def test_get_access_token(registered_clients):


### PR DESCRIPTION
Test snippet:

```python
import epo_ops
cli = epo_ops.Client(accept_type='json', middlewares=[])
reference_type = 'application'
input = epo_ops.models.Original('2006-147056', country_code='JP', kind_code='A')
output_format = 'docdb'
resp = cli.number(reference_type, input, output_format)
print(resp.json())
```

Expected output:

```
{u'ops:world-patent-data': {u'@xmlns': {u'xlink': u'http://www.w3.org/1999/xlink', u'$': u'http://www.epo.org/exchange', u'ops': u'http://ops.epo.org'}, u'ops:standardization': {u'@inputFormat': u'original', u'ops:input': {u'ops:application-reference': {u'document-id': {u'country': {u'$': u'JP'}, u'kind': {u'$': u'A'}, u'@document-id-type': u'original', u'doc-number': {u'$': u'2006-147056'}}}}, u'@outputFormat': u'docdb', u'ops:output': {u'ops:application-reference': {u'document-id': {u'date': {u'$': u'20060526'}, u'country': {u'$': u'JP'}, u'kind': {u'$': u'A'}, u'@document-id-type': u'docdb', u'doc-number': {u'$': u'2006147056'}}}}}, u'ops:meta': [{u'@name': u'status', u'@value': u'BRW002 BRW015'}, {u'@name': u'info', u'@value': u'[26/5/2006]'}, {u'@name': u'version', u'@value': u'11.06.32'}, {u'@name': u'elapsed-time', u'@value': u'34'}]}}
```