### PR TITLE
Add images retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Currently the Client knows how to issue request for the following services:
 | Client method                                                                 | API end point         | throttle  |
 |-------------------------------------------------------------------------------|-----------------------|-----------|
 | `family(reference_type, input, endpoint=None, constituents=None)`             | family                | inpadoc   |
+| `image(path, range=1, extension='tiff')`                                      | published-data/images | other     |
 | `number(reference_type, input, output_format)`                                | number-service        | other     |
 | `published_data(reference_type, input, endpoint='biblio', constituents=None)` | published-data        | retrieval |
 | `published_data_search(cql, range_begin=1, range_end=25, constituents=None)`  | published-data/search | search    |
@@ -64,7 +65,6 @@ See the [OPS guide][] for more information on how to use each service.
 Please submit pull requests for the following services by enhancing the `epo_ops.api.Client` class:
 
 * Legal service
-* Images retrieval
 * Bulk operations
 
 

--- a/tests/helpers/api_helpers.py
+++ b/tests/helpers/api_helpers.py
@@ -8,6 +8,8 @@ from epo_ops.models import Original
 
 data = ('publication', Docdb('1000000', 'EP', 'A1'))
 rdata = ('publication', Epodoc('EP1000000'))
+idata = ('published-data/images/EP/1000000/A1/fullimage', 1)
+# idata path is the result @path from images published-data json request
 
 
 def find_range(document, pattern):
@@ -23,6 +25,12 @@ def assert_family_success(client):
     response = client.family(*data)
     assert_request_success(response)
     assert 'patent-family' in response.text
+    return response
+
+
+def assert_image_success(client):
+    response = client.image(*idata)
+    assert_request_success(response)
     return response
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,8 @@ from epo_ops.exceptions import InvalidNumberConversion
 from epo_ops.middlewares.throttle.storages import sqlite
 
 from .helpers.api_helpers import (
-    assert_family_success, assert_number_service_success,
+    assert_family_success, assert_image_success,
+    assert_number_service_success,
     assert_published_data_search_success,
     assert_published_data_search_with_range_success,
     assert_published_data_success, assert_register_search_success,
@@ -26,6 +27,10 @@ def test_instantiate_simple_client():
 
 def test_family(all_clients):
     assert_family_success(all_clients)
+
+
+def test_image(all_clients):
+    assert_image_success(all_clients)
 
 
 def test_published_data(all_clients):


### PR DESCRIPTION
I added images retrieval call. So after retrieving available paths from a patent, for instance:

```
client.published_data(reference_type='publication', input=epo_ops.models.Docdb(
    '1000000', 'EP', 'A1'), endpoint='images')
```

returns `'published-data/images/EP/1000000/A1/fullimage'` as path for FullDocument and number-of-pages.

With this info, we can request with new client.image(path, range), one page per request as described in ops_v3_2 document.