### PR TITLE
Fix caching for 4xx responses from OPS API

### DIFF
--- a/epo_ops/models.py
+++ b/epo_ops/models.py
@@ -91,7 +91,14 @@ class Request(object):
                 self.env, url, data, **kwargs
             )
 
-        response = self.env['response'] or requests.post(url, data, **kwargs)
+        # Either get response from cache environment or request from upstream
+        # Remark:
+        # bool(<Response [200]>) is True
+        # bool(<Response [404]>) is False
+        if self.env['response'] is not None:
+            response = self.env['response']
+        else:
+            response = requests.post(url, data, **kwargs)
 
         for mw in reversed(self.middlewares):
             response = mw.process_response(self.env, response)


### PR DESCRIPTION
Hi George,

unlike [intended](https://github.com/55minutes/python-epo-ops-client/blob/35a1454e/epo_ops/middlewares/cache/dogpile/dogpile.py#L43), all responses from OPS with 4xx status codes did not get cached as the boolean representation of a response object [returns only "True" if its status_code is less than 400](https://github.com/requests/requests/blob/master/requests/models.py#L663).

```
>>> import requests
>>> response = requests.Response()
>>> response.status_code = 404
>>> bool(response)
False
```

This fix resolves issue #24 we ran into the other day. 

Thanks again for this great library!

With kind regards,
Andreas.
