### PR TITLE
JsonResponse Middleware

### DIFF
--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -8,9 +8,9 @@ import requests
 from requests.exceptions import HTTPError
 
 from . import exceptions
-from .middlewares import Throttler
+from .middlewares import Throttler, JsonResponse
 from .models import AccessToken, Request
-
+from .settings import INSTALLED_MIDDLEWARE
 log = logging.getLogger(__name__)
 
 
@@ -33,6 +33,11 @@ class Client(object):
         self.middlewares = middlewares
         if middlewares is None:
             self.middlewares = [Throttler()]
+        else:
+            try:
+                self.middlewares = [INSTALLED_MIDDLEWARE[m] for m in middlewares]
+            except Exception as e:
+                print(e)
         self.request = Request(self.middlewares)
         self.key = key
         self.secret = secret

--- a/epo_ops/middlewares/__init__.py
+++ b/epo_ops/middlewares/__init__.py
@@ -2,6 +2,7 @@
 
 from .middleware import Middleware
 from .throttle import Throttler
+from .json import JsonResponse
 
 try:
     from .cache import Dogpile

--- a/epo_ops/middlewares/json/JsonResponse.py
+++ b/epo_ops/middlewares/json/JsonResponse.py
@@ -1,0 +1,16 @@
+from ..middleware import Middleware
+import xmltodict
+import json
+
+def xml_json(response):
+    return json.dumps(xmltodict.parse(response.text))
+
+class JsonResponse(Middleware):
+    def __init__(self):
+        pass
+    def process_request(self, env, url, data, **kwargs):
+        return url, data, kwargs
+
+    def process_response(self, env, response):
+        response.json = xml_json
+        return response

--- a/epo_ops/middlewares/json/__init__.py
+++ b/epo_ops/middlewares/json/__init__.py
@@ -1,0 +1,1 @@
+from .JsonResponse import JsonResponse

--- a/epo_ops/settings.py
+++ b/epo_ops/settings.py
@@ -1,0 +1,8 @@
+from .middlewares import *
+
+INSTALLED_MIDDLEWARE = {
+    "throttler": Throttler(),
+    "json_response": JsonResponse(),
+}
+
+

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,4 @@
 python-dateutil
 requests
 six
+xmltodict

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,3 +11,4 @@ python-dateutil==2.6.1
 requests==2.18.4
 six==1.11.0
 urllib3==1.22             # via requests
+xmltodict

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,3 +48,4 @@ urllib3==1.22             # via requests
 virtualenv==15.1.0        # via tox
 wcwidth==0.1.7            # via prompt-toolkit
 wheel==0.30.0
+xmltodict

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ packages = [
     'epo_ops',
 ]
 
-requires = ['python-dateutil', 'requests', 'six']
+requires = ['python-dateutil', 'requests', 'six', 'xmltojson']
 
 readme = open('README.rst').read()
 history = open('HISTORY.rst').read()


### PR DESCRIPTION
Set available in the form of dictionary middlewares in settings.py, then the middlewares can be specified as a list of strings when instantiating Client using argument like middlewares=["throttler","json_response"].

JsonResponse middleware:
Adding this middleware will enable json(response) method in response, which returns the Json form of the response body