### PR TITLE
eliminate docdb model requirement of kind_code

### DIFF
--- a/epo_ops/models.py
+++ b/epo_ops/models.py
@@ -39,11 +39,7 @@ class Original(BaseInput):
 
 
 class Docdb(BaseInput):
-    def __init__(self, number, country_code, kind_code, date=None):
-        if not all([country_code, kind_code]):
-            raise MissingRequiredValue(
-                'number, country_code, and kind_code must be present'
-            )
+    def __init__(self, number, country_code, kind_code=None, date=None):
         super(Docdb, self).__init__(number, country_code, kind_code, date)
 
 


### PR DESCRIPTION
- epo api accepts/generates docdb numbers without a kind code
- the previous error is no longer necessary
- additionally, the error would never run because the paramaters that are required don't have defaults, they wouldn't be called