### PR TITLE
Added bulk operations for published data. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ Currently the Client knows how to issue request for the following services:
 | `register_search(cql, range_begin=1, range_end=25)`                           | register/search       | other     |
 | `register_search(cql, range_begin=1, range_end=25)`                           | register/search       | other     |
 
+Bulk operations can be achieved by passing a list of valid models to the published_data input field.
+
 See the [OPS guide][] or use the [Developer's Area][] for more information on how to use each service.
 
 Please submit pull requests for the following services by enhancing the `epo_ops.api.Client` class:
 
 * Legal service
-* Bulk operations
 
 
 ### Middleware

--- a/TODOS.md
+++ b/TODOS.md
@@ -13,7 +13,6 @@
 
 ## Additional services
 * Legal service
-* Bulk operations
 
 ## Makefile
 * Comma in `echo` statements?

--- a/epo_ops/api.py
+++ b/epo_ops/api.py
@@ -97,10 +97,18 @@ class Client(object):
     def _service_request(
         self, path, reference_type, input, endpoint, constituents
     ):
-        url = self._make_request_url(
-            path, reference_type, input, endpoint, constituents
-        )
-        return self._make_request(url, input.as_api_input())
+        if type(input) == list:
+
+            url = self._make_request_url(
+                path, reference_type, input[0], endpoint, constituents
+            )
+            data = "\n".join([i.as_api_input() for i in input])
+        else:
+            url = self._make_request_url(
+                path, reference_type, input, endpoint, constituents
+            )
+            data = input.as_api_input()
+        return self._make_request(url, data)
 
     def _search_request(self, path, cql, range, constituents=None):
         url = self._make_request_url(path, None, None, None, constituents)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def reset_cached_client(request):
     params=['reset_cached_client']
 )
 def reset_cached_clients(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(scope='module')
@@ -51,7 +51,7 @@ def cached_client(request, module_cache):
     params=['cached_client', 'default_client']
 )
 def clients(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(
@@ -59,7 +59,7 @@ def clients(request):
     params=['default_client']
 )
 def non_cached_clients(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(
@@ -67,7 +67,7 @@ def non_cached_clients(request):
     params=['cached_client']
 )
 def cached_clients(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)
 
 
 @pytest.fixture(
@@ -75,4 +75,4 @@ def cached_clients(request):
     params=['cached_client', 'default_client']
 )
 def all_clients(request):
-    return request.getfuncargvalue(request.param)
+    return request.getfixturevalue(request.param)

--- a/tests/helpers/api_helpers.py
+++ b/tests/helpers/api_helpers.py
@@ -105,3 +105,9 @@ def assert_number_service_success(client):
     response = issue_number_request(client, 'docdb')
     assert 'ops:standardization' in response.text
     return response
+
+def assert_bulk_service_retrival_success(client):
+    input_list = [Docdb('1000000', 'EP', 'A1'), Epodoc('US2018265402')]
+    response = client.published_data('publication', input=input_list)
+
+    assert response.status_code == requests.codes.ok

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,7 +15,7 @@ from .helpers.api_helpers import (
     assert_published_data_search_with_range_success,
     assert_published_data_success, assert_register_search_success,
     assert_register_search_with_range_success, assert_register_success,
-    issue_number_request, issue_published_data_request
+    issue_number_request, issue_published_data_request, assert_bulk_service_retrival_success
 )
 
 
@@ -44,6 +44,8 @@ def test_published_data_search(all_clients):
 def test_published_data_search_with_range(all_clients):
     assert_published_data_search_with_range_success(all_clients)
 
+def test_bulk_published_data_retreval(all_clients):
+    assert_bulk_service_retrival_success(all_clients)
 
 def test_register(all_clients):
     assert_register_success(all_clients)


### PR DESCRIPTION
Added functionality for bulk operations for published data by adding list detection and handling to api.Client._service_request.

Also updated conftest.py to use getfixturevalue since getfuncargvalue is deprecated and was causing many tests to fail.

There are still three tests that are failing (test_docdb_required, test_throttling, and test_400_expired_token) but they fail with or without my pull request.

